### PR TITLE
Set default text color.

### DIFF
--- a/tmpl.tmpl
+++ b/tmpl.tmpl
@@ -21,6 +21,7 @@ h1 {
 }
 body {
 	background: #eaeaea;
+	color: black;
 	margin: 0;
 	padding: 0;
 	height: 100%;


### PR DESCRIPTION
The CSS had a `background-color` defined in `body {}`, but no `color`. This patch sets it to black, because it cannot be assumed that everyone has configured black as fallback color in their browser.